### PR TITLE
Bugfix: max denoms not used when second highest is insufficiant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,32 +1,43 @@
 # Next up
 
-# v 0.0.6
+## v 1.0.1
+
+### Fixed
+
+- Bug where rounding would not use the highest denomination
+
+## v 1.0.0
+
+- Overhauled calculations to be more modular
+- Updated to Foundry v14
+
+## v 0.0.6
 
 - Moved styles to styles/*
 - Adjusted code order/formatting
 - Removed var defining ApplicationV2 as it can be referenced directly
 
-# v 0.0.5
+## v 0.0.5
 
 - Config playerPartyApp & playerCurrencyApp added
   - Toggles if players can use the apps
 - Fix toggleApp Function
 - Remove TS Console Logs
 
-# v 0.0.4
+## v 0.0.4
 
 - Config displayHPValue added
 
-# v 0.0.3
+## v 0.0.3
 
 - Double Buttons fix
 
-# v 0.0.2
+## v 0.0.2
 
 - Refactor Main.js to reduce code duplication.
 - Remove v2 from app file names, classes, and vars
 - Remove Unused delcarations
 
-# v 0.0.1
+## v 0.0.1
 
 - Inital Release

--- a/scripts/currency-calc.js
+++ b/scripts/currency-calc.js
@@ -143,6 +143,7 @@ export default class CurrencySpenderApp extends foundry.applications.api.Applica
       }
     } else {
       const convList = conversionList
+      convList[commonTypes.max] = ""
       const roundedCost = structuredClone(purchaseValue);
       for (const [type, conv] of Object.entries(convList)) {
         var valueTypes = coinTypes.toReversed();


### PR DESCRIPTION
### Fixed

- Bug where rounding would not use the highest denomination