### PR TITLE
Release: 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next up
 
+## v 1.0.1
+
 ### Fixed
 
 - Bug where rounding would not use the highest denomination

--- a/module.json
+++ b/module.json
@@ -8,9 +8,9 @@
       "discord": "bowenarrows"
     }
   ],
-  "version": "1.0.0",
-  "download": "https://github.com/BowenArrows2K/bowenarrows-utils/releases/download/1.0.0/bowenarrows-utils.zip",
-  "manifest": "https://github.com/BowenArrows2K/bowenarrows-utils/releases/download/1.0.0/module.json",
+  "version": "1.0.1",
+  "download": "https://github.com/BowenArrows2K/bowenarrows-utils/releases/download/1.0.1/bowenarrows-utils.zip",
+  "manifest": "https://github.com/BowenArrows2K/bowenarrows-utils/releases/download/1.0.1/module.json",
   "url": "https://github.com/BowenArrows2K/bowenarrows-utils",
   "readme": "https://github.com/BowenArrows2K/bowenarrows-utils/blob/main/README.md",
   "compatibility": {


### PR DESCRIPTION
## v 1.0.1

### Fixed

- Bug where rounding would not use the highest denomination
- Swapped currency spender app icon to reduce confusion for Manage Currency from character sheet